### PR TITLE
feat: extend AgentState for Shortlist domain

### DIFF
--- a/app/models/schemas/__init__.py
+++ b/app/models/schemas/__init__.py
@@ -1,5 +1,27 @@
 """Domain-specific Pydantic schemas."""
 
 from app.models.schemas.base import BaseSchema
+from app.models.schemas.shortlist import (
+    Candidate,
+    ComparisonTable,
+    DataType,
+    FieldCategory,
+    FieldDefinition,
+    RefinementEntry,
+    RefinementTrigger,
+    UserRequirements,
+    WorkflowPhase,
+)
 
-__all__ = ["BaseSchema"]
+__all__ = [
+    "BaseSchema",
+    "Candidate",
+    "ComparisonTable",
+    "DataType",
+    "FieldCategory",
+    "FieldDefinition",
+    "RefinementEntry",
+    "RefinementTrigger",
+    "UserRequirements",
+    "WorkflowPhase",
+]

--- a/app/models/schemas/shortlist.py
+++ b/app/models/schemas/shortlist.py
@@ -1,0 +1,108 @@
+"""Shortlist domain-specific Pydantic schemas."""
+
+from enum import Enum
+
+from pydantic import Field
+
+from app.models.schemas.base import BaseSchema
+
+
+class WorkflowPhase(str, Enum):
+    """Workflow phase enumeration."""
+
+    INTAKE = "intake"
+    RESEARCH = "research"
+    ADVISE = "advise"
+
+
+class UserRequirements(BaseSchema):
+    """User requirements for product search."""
+
+    product_type: str = Field(..., description="Type of product the user is looking for")
+    budget_min: float | None = Field(None, description="Minimum budget in USD", ge=0)
+    budget_max: float | None = Field(None, description="Maximum budget in USD", ge=0)
+    must_haves: list[str] = Field(
+        default_factory=list,
+        description="Required features or characteristics",
+    )
+    nice_to_haves: list[str] = Field(
+        default_factory=list,
+        description="Preferred but not required features",
+    )
+    priorities: list[str] = Field(
+        default_factory=list,
+        description="Ordered list of user priorities (e.g., 'price', 'quality', 'brand')",
+    )
+    constraints: list[str] = Field(
+        default_factory=list,
+        description="Constraints or limitations (e.g., 'must ship to Canada', 'eco-friendly only')",
+    )
+
+
+class Candidate(BaseSchema):
+    """Product candidate model."""
+
+    name: str = Field(..., description="Product name")
+    manufacturer: str = Field(..., description="Manufacturer or brand name")
+    official_url: str | None = Field(None, description="Official product URL")
+    description: str | None = Field(None, description="Product description")
+    category: str | None = Field(None, description="Product category or type")
+
+
+class FieldCategory(str, Enum):
+    """Field category enumeration."""
+
+    STANDARD = "standard"
+    CATEGORY = "category"
+    USER_DRIVEN = "user_driven"
+
+
+class DataType(str, Enum):
+    """Data type enumeration for field definitions."""
+
+    STRING = "string"
+    NUMBER = "number"
+    BOOLEAN = "boolean"
+    LIST = "list"
+    DICT = "dict"
+
+
+class FieldDefinition(BaseSchema):
+    """Definition for a comparison table field."""
+
+    name: str = Field(..., description="Field name")
+    prompt: str = Field(..., description="Prompt to use when extracting this field")
+    data_type: DataType = Field(..., description="Expected data type for this field")
+    category: FieldCategory = Field(
+        ..., description="Field category (standard/category/user-driven)"
+    )
+
+
+class ComparisonTable(BaseSchema):
+    """Comparison table holding enriched candidate data."""
+
+    fields: list[FieldDefinition] = Field(
+        default_factory=list,
+        description="Field definitions for the comparison table",
+    )
+    data: dict[str, dict[str, any]] = Field(
+        default_factory=dict,
+        description="Enriched candidate data, keyed by candidate name",
+    )
+
+
+class RefinementTrigger(str, Enum):
+    """Trigger type for refinement."""
+
+    USER_REQUEST = "user_request"
+    INSUFFICIENT_DATA = "insufficient_data"
+    NEW_REQUIREMENTS = "new_requirements"
+    FIELD_ADDITION = "field_addition"
+
+
+class RefinementEntry(BaseSchema):
+    """Entry tracking a refinement loop iteration."""
+
+    loop_count: int = Field(..., description="Refinement loop iteration number", ge=1)
+    what_changed: str = Field(..., description="Description of what changed in this iteration")
+    trigger: RefinementTrigger = Field(..., description="What triggered this refinement")

--- a/app/models/state.py
+++ b/app/models/state.py
@@ -88,15 +88,24 @@ class AgentState(TypedDict, total=False):
     openai_response_id: str | None
 
     # =========================================================================
-    # Domain-Specific Fields (Placeholders)
+    # Domain-Specific Fields (Shortlist)
     # =========================================================================
-    # TODO: Add your domain-specific fields here
-    #
-    # Examples:
-    # - classification_result: dict
-    # - knowledge_context: list[str]
-    # - tools_used: list[str]
-    # - confidence_score: float
+    # User requirements for product search
+    user_requirements: dict[str, Any] | None
+
+    # Product candidates
+    candidates: list[dict[str, Any]]
+
+    # Comparison table with enriched candidate data
+    comparison_table: dict[str, Any] | None
+
+    # Refinement history
+    refinement_history: list[dict[str, Any]]
+
+    # Workflow control flags
+    need_new_search: bool
+    new_fields_to_add: list[str]
+    current_phase: str  # intake, research, advise
 
 
 # =============================================================================
@@ -142,4 +151,12 @@ def create_initial_state(
         web_search_citations=[],
         web_search_sources=[],
         openai_response_id=None,
+        # Shortlist-specific fields
+        user_requirements=None,
+        candidates=[],
+        comparison_table=None,
+        refinement_history=[],
+        need_new_search=False,
+        new_fields_to_add=[],
+        current_phase="intake",
     )


### PR DESCRIPTION
## Summary

Extends AgentState with domain-specific models for the Shortlist 3-phase workflow (intake/research/advise).

Part of Epic #3
Closes #4

## Changes

- Created `app/models/schemas/shortlist.py` with all required Pydantic models
- Extended `AgentState` in `app/models/state.py` with shortlist-specific fields
- Updated `create_initial_state()` factory function to initialize new fields
- Follows fat state pattern and TypedDict for LangGraph compatibility

## Models Added

- `UserRequirements` - product search criteria
- `Candidate` - product candidate information
- `FieldDefinition` - comparison table field schema
- `ComparisonTable` - enriched candidate data storage
- `RefinementEntry` - refinement loop tracking
- `WorkflowPhase` enum - INTAKE, RESEARCH, ADVISE

## Test Plan

- [x] `make check` passes (linting and formatting)
- [ ] Verify state can be instantiated with new fields
- [ ] Confirm Pydantic models validate correctly
- [ ] Test in integration with workflow nodes

---

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shortlist workflow system with three phases: intake, research, and advise.
  * Enabled tracking of user requirements including budget and preferences.
  * Introduced candidate comparison table with customizable fields and data types.
  * Added refinement history to track workflow changes and iterations.
  * Implemented category and data type definitions for structured field management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->